### PR TITLE
Show extension above DM image modal

### DIFF
--- a/content/src/StickyScrollingContainer.jsx
+++ b/content/src/StickyScrollingContainer.jsx
@@ -34,7 +34,7 @@ function StickyScrollingContainer({ children, mediaRect, shouldUnmount }) {
         overflow: 'hidden',
         width: '340px',
         height: '60px',
-        zIndex: '100',
+        zIndex: '9999',
       }}
     >
       {children}

--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,7 @@
     "48": "icon_48.png",
     "128": "icon_128.png"
   },
-  "version": "2.0.22",
+  "version": "2.0.23",
   "content_scripts": [
     {
       "matches": ["*://*.instagram.com/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "HighResolutionDownloaderForInstagram",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "private": true,
   "description": "",
   "dependencies": {


### PR DESCRIPTION
Instagram has added DMs to the web. You can send images directly via DM, and they appear in a new modal. This modal's z-index is 100, which is the same z-index as this extension.

For the extension to appear above the modal regardless of DOM order, its z-index must be higher. I've increased the z-index to a very high number to prevent a similar bug from occurring in the near future.

Fixes #53 